### PR TITLE
Affiliate all the Kinvolk engineers with Kinvolk

### DIFF
--- a/developers_affiliations.txt
+++ b/developers_affiliations.txt
@@ -224,7 +224,7 @@ Alan Jones: watercraftsoftware!gmail.com
 Alan Williams: alanwill81!gmail.com
 	Google
 Alban Crequy: alban!kinvolk.io
-	CoreOS
+	Kinvolk
 Albert Vaca: albertvaka!gmail.com
 	Verse Technologies
 Albert Zhang: zhgwenming!gmail.com
@@ -1005,7 +1005,7 @@ Chris Knowles: c-knowles!users.noreply.github.com, chris.knowles!bitgamelabs.com
 	Bitgame Labs
 	Omnifone until 2015-11-15
 Chris Kühl: chris!kinvolk.io
-	CoreOS
+	Kinvolk
 Chris Love: clove!cnmconsulting.net
 	CNM Consulting
 Chris Machler: chris.machler!evergreenitco.com
@@ -1898,7 +1898,7 @@ Hunter Nield: hunternield!gmail.com
 Hyunchel Kim: hyunchel!fashionmetric.com
 	Bold Metrics
 Iago López Galeiras: iago!kinvolk.io
-	CoreOS
+	Kinvolk
 Iain Cambridge: iain!humblyarrogant.io
 	NotFound
 Ian Beringer: ian!ianberinger.com
@@ -3278,7 +3278,7 @@ Michal Gebauer: mishak!mishak.net
 Michal Minar: miminar!redhat.com
 	Red Hat
 Michal Rostecki: michal!kinvolk.io, mrostecki!mirantis.com
-	CoreOS
+	Kinvolk
 	Mirantis until 2016-11-30
 	Self until 2015-08-19
 	Allegro until 2015-08-07
@@ -4012,7 +4012,7 @@ Robert Deusser: iamthemuffinman!outlook.com
 	Roche until 2016-01-15
 	The AME Group until 2014-05-15
 Robert Günzler: robertguenzler!kinvolk.io
-	CoreOS
+	Kinvolk
 Robert Jefe Lindstaedt: robert.lindstaedt!gmail.com
 	Self
 Robert Kozikowski: r.kozikowski!gmail.com


### PR DESCRIPTION
For some reason all of the Kinvolk engineers were affiliated with CoreOS. This corrects that error.